### PR TITLE
add // @dart=2.9 to avoid Dart higher version's nullsafety

### DIFF
--- a/lisp.dart
+++ b/lisp.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env dart
+// @dart=2.9
 // Nukata Lisp 2.00.0 in Dart 2.5 (H27.03.16/R01.11.02) by SUZUKI Hisao
 
 import "dart:async";


### PR DESCRIPTION
add // @dart=2.9 to avoid Dart higher version's nullsafety